### PR TITLE
AWG5208 waveform wrap/drift when triggerred externally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Jupiter notebook checkpoints
+*/.ipynb_checkpoints/
+
+# PyCharm-related files
+.idea/

--- a/instruments/Tektronix/awg_waveform_wrap_when_triggered/README.md
+++ b/instruments/Tektronix/awg_waveform_wrap_when_triggered/README.md
@@ -4,11 +4,13 @@ This problem appears for Tektronix AWG5208 with `6.0.0242.0`
  firmware version (might be also for all `6.0.*` versions).
 
 The problem is that when a waveform is triggered externally, after a number 
-of external triggers, it gets wrapped around. In other words, it is played 
-not at its start but at a point a bit further along. Moreover, the point from
- which the waveform is played is slowly shifting.
+of external triggers, it gets wrapped around (i.e. its starting point drifts).
+In other words, it is played not at its start but at a point a bit further 
+along. Moreover, the point from which the waveform is played is slowly shifting.
  
 Newer versions of the firmware, at least `6.1.0054.0` (and presumably all 
-`6.1.*` versions), do not exhibit this problem. 
+`6.1.*` versions), do not exhibit this problem. Thus, in case AWG5208 
+waveforms need to be triggered externally, then the AWG has to have the 
+firmware with the abovementioned version installed.  
  
 For more information, refer to the report in `report.rst`.

--- a/instruments/Tektronix/awg_waveform_wrap_when_triggered/README.md
+++ b/instruments/Tektronix/awg_waveform_wrap_when_triggered/README.md
@@ -1,0 +1,14 @@
+# Waveform wrapped when triggered externally
+
+This problem appears for Tektronix AWG5208 with `6.0.0242.0`
+ firmware version (might be also for all `6.0.*` versions).
+
+The problem is that when a waveform is triggered externally, after a number 
+of external triggers, it gets wrapped around. In other words, it is played 
+not at its start but at a point a bit further along. Moreover, the point from
+ which the waveform is played is slowly shifting.
+ 
+Newer versions of the firmware, at least `6.1.0054.0` (and presumably all 
+`6.1.*` versions), do not exhibit this problem. 
+ 
+For more information, refer to the report in `report.rst`.

--- a/instruments/Tektronix/awg_waveform_wrap_when_triggered/report.rst
+++ b/instruments/Tektronix/awg_waveform_wrap_when_triggered/report.rst
@@ -1,0 +1,78 @@
+Waveform wrapped when triggered externally on the AWG5208
+=========================================================
+
+
+Abstract
+--------
+
+When a waveform is triggered externally on ``AWG5208`` with firmware version
+``6.0.0242.0``, after a number of triggers, it gets wrapped, i.e. it is
+played not from its beginning but a bit later. In order to avoid this
+problem, just use a newer version of firmware; ``6.1.0054.0`` is confirmed
+to not exhibit this problem.
+
+
+Setup
+-----
+
+The basic setup for testing this contains the Tektronix AWG5208, Keysight
+Infiniium MSOS254A mixed signal oscilloscope, and Rigol DG1062 signal
+generator. First channel of the AWG is connected to the scope, together with
+one marker channel. Signal generator is connected to the ``TrigA`` input of
+the AWG, and to the scope.
+
+A program was written to upload a simple staircase ramp waveform with triggers
+for each step to the first channel of the AWG. The total duration of the
+waveform was ~10ms, the number of steps (and triggers) was 10. The waveform
+starts in the event of receiving signal from TrigA, which is set to 0V level,
+with rising edge, 50 Ohm impedance, and Fast timing. The sample rate was
+10 MS/s.
+
+The signal generator was setup to emit a step from -0.5V to +0.5V. Emitting
+this signal was commanded from the program.
+
+The flow of the experiment is the following:
+
+- Upload the waveform to AWG
+- Set up the signal generator
+- Set up the scope to view the output of AWG together with the signal emitted
+  from the signal generator
+- Press "Play" on AWG so that the waveform is ready to be played
+- Periodically send commands to the signal generator to emit the trigger
+  signal, and observe the signals that AWG emits on the scope
+
+
+Results
+-------
+
+The observed behavior is the following. After a number of times the waveform
+is played (~20), the first trigger from the waveform suddenly disappears, and
+appears at the end of the waveform. Together with this, the observer also
+notices that the not only the first trigger got moved to the end of the
+waveform, but the whole staircase ramp pattern got shifted. After more times
+of playing the waveform, the "drifting" continues, and the two of the first
+trigger signals from the marker channel are now at the end of the waveform.
+
+Note that neither sample rate, nor duration of the waveform matter. While
+preserving the shape of the waveform and increasing the sample rate to
+maximum, the number of times the waveform needed to be played, in order for
+the drift/wrapping to be observed, increased. Nevertheless, when the number
+of steps within the staircase ramp pattern has been increased, the
+drift/wrapping started to appear earlier again.
+
+
+Solution
+--------
+
+The solution was found to be just using a later version of the firmware. In
+particular, the same measurement has been performed with AWG5208 with
+``6.1.0054.0`` firmware version, and the drift/wrapping behavior has not been
+observed.
+
+
+Conclusion
+-----------
+
+In case an experiment is being set up where waveforms from AWG5208
+need to be triggered externally, then the used AWG5208 has to have a firmware
+with the version that is at least ``6.1.0054.0``.


### PR DESCRIPTION
This report describes the problem with AWG5208 `6.0.0242.0` firmware where the waveform that is triggered externally, is being wrapped/drifts after a number of times it gets triggered.

The report lacks python scripts and pictures, because I do not have time to reproduce them, and I do not think it is needed since the problem is fixed in the newer firmware versions (`6.1.0054.0`) which are available for download from Tektronix website.